### PR TITLE
Adding Admin Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ Token `BestTokenEver` stored successfully.
 | TFPIN_SERVER_ADDR  	|   	| :8000  	|
 | TFPIN_SERVER_LOG_LEVEL  	|   	| 3 (warn) 	|
 | TFPIN_AUTH_HEADER_KEY  	|   	| Authorization  	|
-
+| TFPIN_AUTH_ADMIN_USERNAME | | No default value |
+| TFPIN_AUTH_ADMIN_PASSWORD | | No default value |
 ### Docker
 #### Building Image
 

--- a/config/models.go
+++ b/config/models.go
@@ -3,7 +3,9 @@ package config
 var CFG Config
 
 type AuthConfig struct {
-	ApiKeyHeader string // ex. "Authorization"
+	ApiKeyHeader  string // ex. "Authorization"
+	AdminUserName string
+	AdminPassword string
 }
 
 type ClusterConfig struct {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,8 @@ services:
       TFPIN_SERVER_LOG_LEVEL: 6
       TFPIN_DB_LOG_LEVEL: 2
       TFPIN_DB_DSN: "/data/db/pins.db"
+      TFPIN_AUTH_ADMIN_USERNAME: "tfpin"
+      TFPIN_AUTH_ADMIN_PASSWORD: "tfpin"
 
     ports:
       - "8000:80"

--- a/ipfs-controller/controller-interface.go
+++ b/ipfs-controller/controller-interface.go
@@ -19,4 +19,6 @@ type IpfsController interface {
 	Status(ctx context.Context, cid string) (models.Status, error)
 	DagSize(ctx context.Context, key string) (*shell.ObjectStats, error)
 	StatusCids(ctx context.Context, cids []string) (map[string]models.Status, error)
+	Alerts(ctx context.Context) ([]api.Alert, error)
+	Peers(ctx context.Context) ([]api.ID, error)
 }

--- a/main.go
+++ b/main.go
@@ -112,6 +112,14 @@ func LoadConfigFromEnv() (config.Config, error) {
 	if !ok {
 		auth_header_key = "Authorization"
 	}
+	auth_admin_username, ok := os.LookupEnv("TFPIN_AUTH_ADMIN_USERNAME")
+	if !ok {
+		return cfg, errors.New("`TFPIN_AUTH_ADMIN_USERNAME` need to be set")
+	}
+	auth_admin_password, ok := os.LookupEnv("TFPIN_AUTH_ADMIN_PASSWORD")
+	if !ok {
+		return cfg, errors.New("`TFPIN_AUTH_ADMIN_PASSWORD` need to be set")
+	}
 
 	cc := config.ClusterConfig{
 		Host:                 cluster_host,
@@ -138,7 +146,9 @@ func LoadConfigFromEnv() (config.Config, error) {
 		Addr: server_addr,
 	}
 	ac := config.AuthConfig{
-		ApiKeyHeader: auth_header_key,
+		ApiKeyHeader:  auth_header_key,
+		AdminUserName: auth_admin_username,
+		AdminPassword: auth_admin_password,
 	}
 	lc := config.LoggerConfig{
 		LogLevel: server_ll_int,

--- a/pinning-api/controller/handlers.go
+++ b/pinning-api/controller/handlers.go
@@ -421,3 +421,32 @@ func (h *Handlers) ReplacePinByRequestId(c *gin.Context) {
 	}
 	c.JSON(http.StatusAccepted, gin.H{})
 }
+
+func (h *Handlers) GetPeers(c *gin.Context) {
+	cl, err := ipfsController.GetClusterController(h.Config.Cluster)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewAPIError(http.StatusInternalServerError, err.Error()))
+		return
+	}
+	peersInfo, err := cl.Peers(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewAPIError(http.StatusInternalServerError, err.Error()))
+		return
+	}
+	c.JSON(http.StatusOK, peersInfo)
+
+}
+
+func (h *Handlers) GetAlerts(c *gin.Context) {
+	cl, err := ipfsController.GetClusterController(h.Config.Cluster)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewAPIError(http.StatusInternalServerError, err.Error()))
+		return
+	}
+	alerts, err := cl.Alerts(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewAPIError(http.StatusInternalServerError, err.Error()))
+		return
+	}
+	c.JSON(http.StatusOK, alerts)
+}

--- a/pinning-api/controller/routers.go
+++ b/pinning-api/controller/routers.go
@@ -17,6 +17,11 @@ func NewRouter(handlers *Handlers) *gin.Engine {
 	v1.GET("/pins/:requestid", handlers.GetPinByRequestId)
 	v1.GET("/pins", handlers.GetPins)
 	v1.POST("/pins/:requestid", handlers.ReplacePinByRequestId)
+	authorized := router.Group("/admin", gin.BasicAuth(gin.Accounts{
+		handlers.Config.Auth.AdminUserName: handlers.Config.Auth.AdminPassword,
+	}))
+	authorized.GET("/peers/", handlers.GetPeers)
+	authorized.GET("/alerts/", handlers.GetAlerts)
 	return router
 }
 


### PR DESCRIPTION
**Related Issues:**
https://github.com/threefoldtech/tf-pinning-service/issues/8

**New Endpoints:**
`/admin/peers/`  -> Monitoring the nodes participating in the IPFS Cluster
`/admin/alerts/`  -> Monitoring the latest expired metric alerts / health events in the cluster

**New Config:**
The service will depend in these new environment variables to set username and password to access the protected admin routes using Basic access authentication.
`TFPIN_AUTH_ADMIN_USERNAME`
`TFPIN_AUTH_ADMIN_PASSWORD`